### PR TITLE
Change export to import in readme code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Why the name ? because I didn't want to reserve the cookiejar name, since this l
 you can import `Cookie`, `CookieJar`, `wrapFetch` from `mod.ts` file.
 
 ```js
-export { Cookie, CookieJar, wrapFetch} from 'https://deno.land/x/another_cookiejar@v4.0.0/mod.ts';
+import { Cookie, CookieJar, wrapFetch} from 'https://deno.land/x/another_cookiejar@v4.0.0/mod.ts';
 ```
 
 ### wrapFetch


### PR DESCRIPTION
I have been debugging the example code for 10 minutes only to detect it says export instead of import.
It might be worth changing the code example to import so this won't happen to other users.