### PR TITLE
Support empty and double quote wrapped cookie value, clear on setting expired cookie

### DIFF
--- a/cookie.ts
+++ b/cookie.ts
@@ -71,6 +71,9 @@ function isValidName(name: string | undefined) {
 }
 
 function isValidValue(val: string | undefined) {
+  if (val === "") {
+    return true;
+  }
   if (!val) {
     return false;
   }

--- a/cookie.ts
+++ b/cookie.ts
@@ -70,6 +70,14 @@ function isValidName(name: string | undefined) {
   return true;
 }
 
+function trimWrappingDoubleQuotes(val: string) {
+  // the value can be wrapped in double quotes, but can't contain double quotes within the value
+  if (val.length >= 2 && val.at(0) === '"' && val.at(-1) === '"') {
+    return val.slice(1, -1);
+  }
+  return val;
+}
+
 function isValidValue(val: string | undefined) {
   if (val === "") {
     return true;
@@ -196,7 +204,10 @@ export class Cookie {
       return new Cookie();
     }
     const name = keyValuePairString.slice(0, keyValuePairEqualsIndex);
-    const value = keyValuePairString.slice(keyValuePairEqualsIndex + 1);
+    const value = trimWrappingDoubleQuotes(
+      keyValuePairString.slice(keyValuePairEqualsIndex + 1),
+    );
+
     if (!(isValidName(name) && isValidValue(value))) {
       return new Cookie();
     }

--- a/cookie_jar.ts
+++ b/cookie_jar.ts
@@ -122,11 +122,20 @@ export class CookieJar {
         cookieObj.setPath(url);
       }
     }
+
+    if (!cookieObj.isValid()) {
+      return;
+    }
+
     const foundCookie = this.getCookie(cookieObj);
     if (foundCookie) {
       const indexOfCookie = this.cookies.indexOf(foundCookie);
-      this.cookies.splice(indexOfCookie, 1, cookieObj);
-    } else if (cookieObj.isValid() && !cookieObj.isExpired()) {
+      if (!cookieObj.isExpired()) {
+        this.cookies.splice(indexOfCookie, 1, cookieObj);
+      } else {
+        this.cookies.splice(indexOfCookie, 1);
+      }
+    } else if (!cookieObj.isExpired()) {
       this.cookies.push(cookieObj);
     }
 

--- a/cookie_jar_test.ts
+++ b/cookie_jar_test.ts
@@ -435,6 +435,29 @@ Deno.test("CookieJar.setCookie() replaces old cookie completely", () => {
   );
 });
 
+Deno.test("CookieJar.setCookie() clears cookie if cookie has expired (empty value)", () => {
+  const cookieStr1 = "foo=bar; path=/sth; domain=.example.com";
+  const cookie1 = Cookie.from(cookieStr1);
+
+  const cookieJar = new CookieJar([
+    cookie1,
+  ]);
+  assertEquals(
+    cookieJar.getCookies().length,
+    1,
+  );
+
+  cookieJar.setCookie(
+    Cookie.from(
+      "foo=; Expires=Thu, 01-Jan-1970 00:00:10 GMT;path=/sth; domain=.example.com",
+    ),
+  );
+  assertEquals(
+    cookieJar.getCookies().length,
+    0,
+  );
+});
+
 Deno.test("CookieJar.setCookie() adds cookie if name matches but path or domain do not match", () => {
   const cookieStr1 = "foo=bar; path=/sth; domain=.example.com";
   const cookie1 = Cookie.from(cookieStr1);

--- a/cookie_test.ts
+++ b/cookie_test.ts
@@ -79,6 +79,8 @@ Deno.test("Cookie.from()", () => {
   assertEquals(Cookie.from("foo=bar").getCookieString(), "foo=bar");
   assertEquals(Cookie.from("foo=bar").toString(), "foo=bar");
   assertEquals(Cookie.from("foo=bar===").toString(), "foo=bar===");
+  assertEquals(Cookie.from('foo=""').toString(), "foo=");
+  assertEquals(Cookie.from('foo="bar"').toString(), "foo=bar");
 });
 
 Deno.test("Cookie json serialization", () => {

--- a/cookie_test.ts
+++ b/cookie_test.ts
@@ -73,6 +73,7 @@ Deno.test("Cookie.from()", () => {
   assertEquals(cookie.sameSite, "Lax");
 
   // other tests
+  assertEquals(Cookie.from("foo=").getCookieString(), "foo=");
   assertEquals(Cookie.from("foo=bar; ").getCookieString(), "foo=bar");
   assertEquals(Cookie.from("foo=bar;").getCookieString(), "foo=bar");
   assertEquals(Cookie.from("foo=bar").getCookieString(), "foo=bar");


### PR DESCRIPTION
* Support empty cookie value
* Support double quote wrapping of value (`foo="bar"`)
* Clear existing matching cookie when setting expired cookie