### PR TITLE
fix: Implement default path algorithm

### DIFF
--- a/cookie.ts
+++ b/cookie.ts
@@ -374,7 +374,19 @@ export class Cookie {
   }
 
   setPath(url: string | Request | URL) {
-    this.path = parseURL(url).pathname;
+    // https://www.rfc-editor.org/rfc/rfc6265#section-5.1.4
+    const uriPath = parseURL(url).pathname; // step 1
+
+    if (!uriPath || uriPath[0] !== "/") { // step 2
+      this.path = "/";
+    } else {
+      const rightmostSlashIdx = uriPath.lastIndexOf("/");
+      if (rightmostSlashIdx <= 0) { // step 3
+        this.path = "/";
+      } else { // step 4
+        this.path = uriPath.slice(0, rightmostSlashIdx);
+      }
+    }
   }
 
   setExpires(exp: Date | number) {

--- a/cookie_test.ts
+++ b/cookie_test.ts
@@ -164,3 +164,25 @@ Deno.test("Cookie.canSendTo()", () => {
     true,
   );
 });
+
+Deno.test("Cookie.setPath() works according to RFC6265 5.1.4", () => {
+  const testCookie = new Cookie();
+
+  testCookie.setPath("http://x.y");
+  assertStrictEquals(testCookie.path, "/");
+
+  testCookie.setPath("http://x.y/");
+  assertStrictEquals(testCookie.path, "/");
+
+  testCookie.setPath("http://x.y/one");
+  assertStrictEquals(testCookie.path, "/");
+
+  testCookie.setPath("http://x.y/one/");
+  assertStrictEquals(testCookie.path, "/one");
+
+  testCookie.setPath("http://x.y/one/two");
+  assertStrictEquals(testCookie.path, "/one");
+
+  testCookie.setPath("http://x.y/one/two/");
+  assertStrictEquals(testCookie.path, "/one/two");
+});


### PR DESCRIPTION
The issue I'm trying to solve is that I'm interacting with the server that doesn't provide `path` attribute so we must calculate the default based on request URL. It turns out that unless the last "part" of the URL's pathname ends with `/` it should be dropped. This is better described in the [RFC 6265](https://www.rfc-editor.org/rfc/rfc6265#section-5.1.4) and [this SO answer](https://stackoverflow.com/questions/43324480/how-does-a-browser-handle-cookie-with-no-path-and-no-domain#answer-64515458).