### PR TITLE
fix: use first arg as RequestInit when invoked as fetch(Request)

### DIFF
--- a/fetch_wrapper.ts
+++ b/fetch_wrapper.ts
@@ -21,7 +21,16 @@ export function wrapFetch(options: WrapFetchOptions) {
       return await fetch(input);
     }
     const cookieString = cookieJar.getCookieString(input);
-    const interceptedInit = init || {};
+
+    let interceptedInit: RequestInit;
+    if (init) {
+      interceptedInit = init;
+    } else if (input instanceof Request) {
+      interceptedInit = input;
+    } else {
+      interceptedInit = {};
+    }
+
     if (!interceptedInit.headers) {
       interceptedInit.headers = new Headers();
     }


### PR DESCRIPTION
Without this patch when `wrappedFetch` was invoked in this way:

```ts
const req = new Request(...)
const res = await wrappedFetch(req)
```

a completely new `init` would be created with just a single cookie header. This new `init` object would then overwrite all the headers set on the `req` object.
