### PR TITLE
Sets the correct cookie domain when redirected. Fixes #11

### DIFF
--- a/fetch_wrapper.ts
+++ b/fetch_wrapper.ts
@@ -40,7 +40,7 @@ export function wrapFetch(options?: WrapFetchOptions): typeof fetch {
     const response = await fetch(input, interceptedInit);
     response.headers.forEach((value, key) => {
       if (key.toLowerCase() === "set-cookie") {
-        cookieJar.setCookie(value, input);
+        cookieJar.setCookie(value, response.url);
       }
     });
     return response;


### PR DESCRIPTION
This uses [Reponse.url](https://developer.mozilla.org/en-US/docs/Web/API/Response/url) instead of the request url to set the cookie domain.

See issue #11 