### PR TITLE
Handle set-cookie from a redirect response fixes #13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Check runtime issues
       run: deno run --reload mod.ts
     - name: Run tests
-      run: deno test --allow-net=127.0.0.1
+      run: deno test --allow-net=127.0.0.1,localhost
   

--- a/cookie.ts
+++ b/cookie.ts
@@ -260,7 +260,7 @@ export class Cookie {
 
         case "domain":
           if (attrValue) {
-            const domain = parseURL(attrValue).host;
+            const domain = parseURL(attrValue).hostname;
             if (domain) {
               options.domain = domain;
             }
@@ -356,8 +356,10 @@ export class Cookie {
     }
 
     if (this.domain) {
-      const host = urlObj.host; // 'host' includes port number, if specified
-      if (isSameDomainOrSubdomain(this.domain, host)) {
+      // according to rfc 6265 8.5.  Weak Confidentiality,
+      // port should not matter, hence the usage of 'hostname' over 'host'
+      const hostname = urlObj.hostname; // 'host' includes port number, if specified, hostname does not
+      if (isSameDomainOrSubdomain(this.domain, hostname)) {
         return true;
       }
     }
@@ -370,7 +372,7 @@ export class Cookie {
   }
 
   setDomain(url: string | Request | URL) {
-    this.domain = parseURL(url).host;
+    this.domain = parseURL(url).hostname;
   }
 
   setPath(url: string | Request | URL) {

--- a/fetch_wrapper.ts
+++ b/fetch_wrapper.ts
@@ -22,8 +22,8 @@ function isRedirect(status: number): boolean {
 
 // Credit <https://github.com/node-fetch/node-fetch/blob/5e78af3ba7555fa1e466e804b2e51c5b687ac1a2/src/utils/is.js#L68>.
 function isDomainOrSubdomain(destination: string, original: string): boolean {
-  const orig = new URL(original).host;
-  const dest = new URL(destination).host;
+  const orig = new URL(original).hostname;
+  const dest = new URL(destination).hostname;
 
   return orig === dest || orig.endsWith(`.${dest}`);
 }

--- a/fetch_wrapper_test.ts
+++ b/fetch_wrapper_test.ts
@@ -521,12 +521,12 @@ Deno.test("doesn't send sensitive headers after redirect to different domains", 
       "request had `authorization` in headers",
     );
     assertFalse(
-      resHeaders.has("cookie"),
-      "request had `cookie` in headers",
+      resHeaders.get("cookie"),
+      "`cookie` header is not empty",
     );
     assertFalse(
       resHeaders.has("cookie2"),
-      "request had `cookie2` in headers",
+      "`cookie2` header shouldn't be sent! ",
     );
   } finally {
     abortController.abort();

--- a/fetch_wrapper_test.ts
+++ b/fetch_wrapper_test.ts
@@ -169,8 +169,16 @@ Deno.test("WrappedFetch can use the Request and still inject cookies", async () 
     const request = new Request(serverOneUrl + "/echo_headers", {
       headers: { foo: "bar" },
     });
-    const res = await wrappedFetch(request).then((r) => r.json());
-    assertArrayIncludes(res, [["foo", "bar"], ["cookie", "goo=baz"]]);
+    const res = await wrappedFetch(request, { headers: [["thud", "fum"]] })
+      .then((r) => r.json());
+    assertArrayIncludes(res, [
+      ["foo", "bar"],
+      ["thud", "fum"],
+      [
+        "cookie",
+        "goo=baz",
+      ],
+    ]);
   } finally {
     abortController.abort();
   }

--- a/fetch_wrapper_test.ts
+++ b/fetch_wrapper_test.ts
@@ -27,21 +27,22 @@ function drop(resourceName: string) {
 
 const serverOnePort = 53250;
 const serverTwoPort = 53251;
-const serverHostname = "127.0.0.1";
+const serverOneHostname = "127.0.0.1";
+const serverTwoHostname = "localhost";
 
 const serverOneOptions = {
-  hostname: serverHostname,
+  hostname: serverOneHostname,
   port: serverOnePort,
 };
 
 const serverTwoOptions = {
-  hostname: serverHostname,
+  hostname: serverTwoHostname,
   port: serverTwoPort,
 };
 
-const serverOneUrl = `http://${serverHostname}:${serverOnePort}`;
+const serverOneUrl = `http://${serverOneHostname}:${serverOnePort}`;
 
-const serverTwoUrl = `http://${serverHostname}:${serverTwoPort}`;
+const serverTwoUrl = `http://${serverTwoHostname}:${serverTwoPort}`;
 
 async function serverHandler(request: Request): Promise<Response> {
   const { pathname } = new URL(request.url);
@@ -316,7 +317,7 @@ Deno.test("Sets the correct domain in cookies when 302-redirected", async () => 
     ) => r.text());
     assertStrictEquals(
       cookieJar.getCookie({ name: "foo" })?.domain,
-      `${serverHostname}:${serverTwoPort}`,
+      `${serverTwoHostname}`,
     );
   } finally {
     abortController.abort();
@@ -338,11 +339,11 @@ Deno.test("Gets cookies both from 302-redirected and 200 response", async () => 
     ) => r.text());
     assertStrictEquals(
       cookieJar.getCookie({ name: "foo" })?.domain,
-      `${serverHostname}:${serverTwoPort}`,
+      `${serverTwoHostname}`,
     );
     assertStrictEquals(
       cookieJar.getCookie({ name: "redirect_cookie" })?.domain,
-      `${serverHostname}:${serverOnePort}`,
+      `${serverOneHostname}`,
     );
   } finally {
     abortController.abort();

--- a/fetch_wrapper_test.ts
+++ b/fetch_wrapper_test.ts
@@ -167,12 +167,15 @@ Deno.test("WrappedFetch can use the Request and still inject cookies", async () 
     ]);
     const wrappedFetch = wrapFetch({ cookieJar });
     const request = new Request(serverOneUrl + "/echo_headers", {
-      headers: { foo: "bar" },
+      headers: { foo: "bar", zoo: "bum" },
     });
-    const res = await wrappedFetch(request, { headers: [["thud", "fum"]] })
+    const res = await wrappedFetch(request, {
+      headers: [["thud", "fum"], ["zoo", "gut"]],
+    })
       .then((r) => r.json());
     assertArrayIncludes(res, [
       ["foo", "bar"],
+      ["zoo", "gut"], // not 'bum' because init should replace original request options
       ["thud", "fum"],
       [
         "cookie",


### PR DESCRIPTION
TODO:

- [x] Add maxRedirect, redirectCount
- [x] Test better
- [x] Handle if `redirect: "manual"` is sent through fetch options
- [x] Handle when redirected if `redirect: "error"` is sent through fetch options
- [x] Set `response.redirected` when redirected
- [x]  deepStrictEqual assert on user's init so we make sure to not accidentally mutate their init
- [x] Do not forward sensitive headers to third-party domains