### PR TITLE
Resets body, method and content-length when redirected

### DIFF
--- a/fetch_wrapper.ts
+++ b/fetch_wrapper.ts
@@ -121,13 +121,14 @@ export function wrapFetch(options?: WrapFetchOptions): typeof fetch {
 
     // Do not forward sensitive headers to third-party domains.
     if (!isDomainOrSubdomain(originalRequestUrl, redirectUrl)) {
-      for (
-        const name of ["authorization", "www-authenticate"] // cookie headers are handled differently
-      ) {
+      for (const name of ["authorization", "www-authenticate"]) { // cookie headers are handled differently
         filteredHeaders.delete(name);
       }
     }
 
+    filteredHeaders.delete("content-length");
+    interceptedInit.method = "GET";
+    interceptedInit.body = undefined;
     interceptedInit.headers = filteredHeaders;
 
     return await wrappedFetch(redirectUrl, interceptedInit as RequestInit);

--- a/fetch_wrapper.ts
+++ b/fetch_wrapper.ts
@@ -126,9 +126,11 @@ export function wrapFetch(options?: WrapFetchOptions): typeof fetch {
       }
     }
 
-    filteredHeaders.delete("content-length");
-    interceptedInit.method = "GET";
-    interceptedInit.body = undefined;
+    if (interceptedInit.method === "POST") {
+      filteredHeaders.delete("content-length");
+      interceptedInit.method = "GET";
+      interceptedInit.body = undefined;
+    }
     interceptedInit.headers = filteredHeaders;
 
     return await wrappedFetch(redirectUrl, interceptedInit as RequestInit);


### PR DESCRIPTION
This needs to be done, so that the request to the redirected URL is a GET and not with body nor content-length

ref. https://github.com/valeriangalliat/fetch-cookie/blob/master/src/index.ts#L176-L178