### PR TITLE
Only set cookie header if cookieString isn't empty

### DIFF
--- a/fetch_wrapper.ts
+++ b/fetch_wrapper.ts
@@ -66,7 +66,10 @@ export function wrapFetch(options?: WrapFetchOptions): typeof fetch {
       });
     }
 
-    reqHeaders.set("cookie", cookieString);
+    if (cookieString.length) {
+      reqHeaders.set("cookie", cookieString);
+    }
+    
     reqHeaders.delete("cookie2"); // Remove cookie2 if it exists, It's deprecated
 
     interceptedInit.headers = reqHeaders;


### PR DESCRIPTION
At the moment `wrappedFetch` will always send a `cookie` header with each request, even if the header value is empty. Sending an empty cookie header differs from the implementation of most web browsers, makes requests much more recognizable and hinders use for web scraping. This PR ensures a `cookie` header is only set if `cookieString` is not empty.