### PR TITLE
Update README.md to point to newest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import {
   Cookie,
   CookieJar,
   wrapFetch,
-} from "https://deno.land/x/another_cookiejar@v5.0.3/mod.ts";
+} from "https://deno.land/x/another_cookiejar@v5.0.4/mod.ts";
 ```
 
 ### wrapFetch


### PR DESCRIPTION
Currently the README.md points to 5.0.3, but it should point to 5.0.4 so users don't use an outdated version.